### PR TITLE
Default filter property types are now correctly the XSD/GML types.

### DIFF
--- a/src/main/java/au/org/emii/geoserver/extensions/filters/layer/data/io/FilterTypeMapper.java
+++ b/src/main/java/au/org/emii/geoserver/extensions/filters/layer/data/io/FilterTypeMapper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014 IMOS
+ *
+ * The AODN/IMOS Portal is distributed under the terms of the GNU General Public License
+ *
+ */
+
+package au.org.emii.geoserver.extensions.filters.layer.data.io;
+
+import org.geoserver.wfs.xml.GML2Profile;
+import org.geoserver.wfs.xml.TypeMappingProfile;
+import org.geoserver.wfs.xml.XSProfile;
+import org.opengis.feature.type.AttributeType;
+
+/**
+ * Hides some ugly type mapping code in to this one class.
+ */
+public class FilterTypeMapper {
+
+    public String getTypeForClass(Class attributeClass) {
+        AttributeType attrType = getXsdAttributeTypeForClass(attributeClass);
+        if (attrType == null) {
+            attrType = attrType = getGml2AttributeTypeForClass(attributeClass);
+        }
+
+        return attrType.getName().getLocalPart().toLowerCase();
+    }
+
+    private AttributeType getXsdAttributeTypeForClass(Class attributeClass) {
+        TypeMappingProfile xsProfile = new XSProfile();
+        return xsProfile.type(attributeClass);
+    }
+
+    private AttributeType getGml2AttributeTypeForClass(Class attributeClass) {
+        TypeMappingProfile gml2Profile = new GML2Profile();
+        return gml2Profile.type(attributeClass);
+    }
+}

--- a/src/main/java/au/org/emii/geoserver/extensions/filters/layer/data/io/LayerPropertiesReader.java
+++ b/src/main/java/au/org/emii/geoserver/extensions/filters/layer/data/io/LayerPropertiesReader.java
@@ -48,6 +48,7 @@ public class LayerPropertiesReader {
     }
 
     private String getTypeName(FeatureType featureType, AttributeTypeInfo attribute) {
-        return getDescriptor(featureType, attribute).getType().getBinding().getSimpleName();
+        Class attributeClass = getDescriptor(featureType, attribute).getType().getBinding();
+        return new FilterTypeMapper().getTypeForClass(attributeClass);
     }
 }


### PR DESCRIPTION
This is what the portal expects and fixes #16.