### PR TITLE
Fixes bug #19 where java.sql.Timestamps were not being properly encoded ...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+group :development do
+  gem 'guard-maven'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,37 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coderay (1.1.0)
+    ffi (1.9.8)
+    formatador (0.2.5)
+    guard (1.8.3)
+      formatador (>= 0.2.4)
+      listen (~> 1.3)
+      lumberjack (>= 1.0.2)
+      pry (>= 0.9.10)
+      thor (>= 0.14.6)
+    guard-maven (0.2.0)
+      guard (~> 1.8.2)
+    listen (1.3.1)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+      rb-kqueue (>= 0.2)
+    lumberjack (1.0.9)
+    method_source (0.8.2)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    rb-fsevent (0.9.4)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
+    rb-kqueue (0.2.3)
+      ffi (>= 0.5.0)
+    slop (3.6.0)
+    thor (0.19.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  guard-maven

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,5 @@
+guard :maven, all_on_start: true do
+  watch(%r[src/main/.*\.java$]) { 'all' }
+  watch(%r[src/test/.*/(.*)\.java$]) { |m| m[1] }
+  watch(%r[src/.*/resources/.*\.\w+$]) { 'all' }
+end

--- a/src/main/java/au/org/emii/geoserver/extensions/filters/layer/data/ValueEncoder.java
+++ b/src/main/java/au/org/emii/geoserver/extensions/filters/layer/data/ValueEncoder.java
@@ -16,17 +16,17 @@ import java.util.TimeZone;
 
 public class ValueEncoder {
 
-    List<String> encodeValues(Set values) {
+    List<String> encode(Set values) {
         List<String> result = new ArrayList<String>();
 
         for (Object value : values) {
-            result.add(encodeValue(value));
+            result.add(encode(value));
         }
 
         return result;
     }
 
-    String encodeValue(Object unencoded) {
+    String encode(Object unencoded) {
 
         if (unencoded instanceof java.util.Date) {
             SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");

--- a/src/main/java/au/org/emii/geoserver/extensions/filters/layer/data/ValueEncoder.java
+++ b/src/main/java/au/org/emii/geoserver/extensions/filters/layer/data/ValueEncoder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014 IMOS
+ *
+ * The AODN/IMOS Portal is distributed under the terms of the GNU General Public License
+ *
+ */
+
+package au.org.emii.geoserver.extensions.filters.layer.data;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.TimeZone;
+
+public class ValueEncoder {
+
+    List<String> encodeValues(Set values) {
+        List<String> result = new ArrayList<String>();
+
+        for (Object value : values) {
+            result.add(encodeValue(value));
+        }
+
+        return result;
+    }
+
+    String encodeValue(Object unencoded) {
+
+        if (unencoded instanceof java.util.Date) {
+            SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+            return df.format(unencoded);
+        }
+
+        return String.valueOf(unencoded);
+    }
+}

--- a/src/main/java/au/org/emii/geoserver/extensions/filters/layer/data/ValuesDocument.java
+++ b/src/main/java/au/org/emii/geoserver/extensions/filters/layer/data/ValuesDocument.java
@@ -14,11 +14,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import java.text.SimpleDateFormat;
-import java.util.List;
 import java.util.Set;
-import java.util.ArrayList;
-import java.util.Date;
 
 public class ValuesDocument {
 
@@ -27,7 +23,7 @@ public class ValuesDocument {
         Element valuesElement = document.createElement("uniqueValues");
         document.appendChild(valuesElement);
 
-        for (String value : encodeValues(values)) {
+        for (String value : new ValueEncoder().encodeValues(values)) {
               Element element = document.createElement("value");
               element.appendChild(document.createTextNode(value));
               valuesElement.appendChild(element);
@@ -40,57 +36,5 @@ public class ValuesDocument {
         DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
 
         return docBuilder.newDocument();
-    }
-
-    private List<String> encodeValues(Set values) {
-
-        List<String> result = new ArrayList<String>();
-
-        if(!values.isEmpty()) {
-
-            Class clazz = values.iterator().next().getClass();
-
-            if (clazz.equals(Boolean.class)) {
-                for(Object value : values) {
-                    result.add(Boolean.toString((Boolean)value));
-                }
-            }
-            else if (clazz.equals(Integer.class)) {
-                for(Object value : values) {
-                    result.add(Integer.toString((Integer)value));
-                }
-            }
-            else if (clazz.equals(Long.class)) {
-                for(Object value : values) {
-                    result.add(Long.toString((Long)value));
-                }
-            }
-            else if (clazz.equals(Float.class)) {
-                for(Object value : values) {
-                    result.add(Float.toString((Float)value));
-                }
-            }
-            else if (clazz.equals(Double.class)) {
-                for(Object value : values) {
-                    result.add(Double.toString((Double)value));
-                }
-            }
-            else if (clazz.equals(String.class)) {
-                for(Object value : values) {
-                    result.add((String)value);
-                }
-            }
-            else if (clazz.equals(java.sql.Date.class)) {
-                SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-                for(Object value : values) {
-                    result.add(df.format((Date)value ));
-                }
-            }
-            else {
-               throw new RuntimeException("Unrecognized type" );
-            }
-        }
-
-        return result;
     }
 }

--- a/src/main/java/au/org/emii/geoserver/extensions/filters/layer/data/ValuesDocument.java
+++ b/src/main/java/au/org/emii/geoserver/extensions/filters/layer/data/ValuesDocument.java
@@ -23,9 +23,9 @@ public class ValuesDocument {
         Element valuesElement = document.createElement("uniqueValues");
         document.appendChild(valuesElement);
 
-        for (String value : new ValueEncoder().encodeValues(values)) {
+        for (String encodedValue : new ValueEncoder().encode(values)) {
               Element element = document.createElement("value");
-              element.appendChild(document.createTextNode(value));
+              element.appendChild(document.createTextNode(encodedValue));
               valuesElement.appendChild(element);
         }
         return document;

--- a/src/test/java/au/org/emii/geoserver/extensions/filters/layer/data/ValueEncoderTest.java
+++ b/src/test/java/au/org/emii/geoserver/extensions/filters/layer/data/ValueEncoderTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 IMOS
+ *
+ * The AODN/IMOS Portal is distributed under the terms of the GNU General Public License
+ *
+ */
+
+package au.org.emii.geoserver.extensions.filters.layer.data;
+
+import org.junit.Test;
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class ValueEncoderTest {
+
+    @Test
+    public void encodeValueAsStringTest() {
+        Map<Object, String> expectedEncodings = new HashMap<Object, String>();
+        expectedEncodings.put(Boolean.valueOf(true), "true");
+        expectedEncodings.put(Integer.valueOf(123), "123");
+        expectedEncodings.put(Long.valueOf(456l), "456");
+        expectedEncodings.put(Float.valueOf(123.456f), "123.456");
+        expectedEncodings.put(Double.valueOf(3.1415), "3.1415");
+        expectedEncodings.put("i am a string", "i am a string");
+        expectedEncodings.put(new java.sql.Date(3600000), "1970-01-01T01:00:00Z");
+        expectedEncodings.put(new java.sql.Timestamp(7200000), "1970-01-01T02:00:00Z");
+
+        for (Map.Entry<Object, String> encoding : expectedEncodings.entrySet()) {
+            Object unencoded = encoding.getKey();
+            String encoded = encoding.getValue();
+
+            assertEquals(encoded, new ValueEncoder().encodeValue(unencoded));
+        }
+    }
+}

--- a/src/test/java/au/org/emii/geoserver/extensions/filters/layer/data/ValueEncoderTest.java
+++ b/src/test/java/au/org/emii/geoserver/extensions/filters/layer/data/ValueEncoderTest.java
@@ -30,7 +30,7 @@ public class ValueEncoderTest {
             Object unencoded = encoding.getKey();
             String encoded = encoding.getValue();
 
-            assertEquals(encoded, new ValueEncoder().encodeValue(unencoded));
+            assertEquals(encoded, new ValueEncoder().encode(unencoded));
         }
     }
 }


### PR DESCRIPTION
...to String

This change also introduces a bit of test infrastructure in the hope of making development a bit easier (yes, I am the devil for mixing ruby and java, but you don't have to use it if you don't want to).

I *think* another bug was there where Date types were being printed with a 'Z' but weren't actually being converted to UTC.